### PR TITLE
Update strings.xml

### DIFF
--- a/BasicRecordingApiKotlin/app/src/main/res/values/strings.xml
+++ b/BasicRecordingApiKotlin/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <string name="action_create_subs">Create subscriptions</string>
     <string name="settings">Settings</string>
     <string name="ok">OK</string>
-    <string name="permission_rationale">Location data is used as part of the Google Fit API</string>
+    <string name="permission_rationale">Activity data is used as part of the Google Fit API</string>
     <string name="permission_denied_explanation">Permission was denied, but is needed for core
         functionality.</string>
 </resources>


### PR DESCRIPTION
Rationale message referenced the wrong permission: Requested permission is Activity Recognition, not Location (bad copy/paste).